### PR TITLE
Hotfix : Logo Misaligned for frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobstac-awesome-qr",
-    "version": "4.0.2",
+    "version": "4.0.3",
     "description": "MobStac Awesome QR code library",
     "homepage": "https://github.com/mobstac/mobstac-awesome-qr",
     "bugs": "https://github.com/mobstac/mobstac-awesome-qr/issues",

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -1977,8 +1977,8 @@ export class SVGDrawing {
 
         const logoXLength = this.calculatedLogoWidth + 10;
         const logoYLength = this.calculatedLogoHeight + 10;
-        const dotXPosition = dataDotLeftPosition ;
-        const dotYPosition = dataDotTopPosition ;
+        const dotXPosition = dataDotLeftPosition + this.shiftX;
+        const dotYPosition = dataDotTopPosition + this.shiftY ;
 
         if( dotXPosition >= logoXPosition && 
             dotXPosition <= logoXPosition + logoXLength && 


### PR DESCRIPTION
Hotfix : This hotfix is for logo background getting misalinged due to frames. Position of data dot was calculated wrongly.