### PR TITLE
Hotfix : Logo background for frames misaligned

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobstac-awesome-qr",
-    "version": "2.4.1-beta.0",
+    "version": "2.4.2-beta.0",
     "description": "MobStac Awesome QR code library",
     "homepage": "https://github.com/mobstac/mobstac-awesome-qr",
     "bugs": "https://github.com/mobstac/mobstac-awesome-qr/issues",

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -1845,8 +1845,8 @@ export class SVGDrawing {
 
         const logoXLength = this.calculatedLogoWidth + 10;
         const logoYLength = this.calculatedLogoHeight + 10;
-        const dotXPosition = dataDotLeftPosition ;
-        const dotYPosition = dataDotTopPosition ;
+        const dotXPosition = dataDotLeftPosition + this.shiftX ;
+        const dotYPosition = dataDotTopPosition + this.shiftY ;
 
         if( dotXPosition >= logoXPosition && 
             dotXPosition <= logoXPosition + logoXLength && 


### PR DESCRIPTION
Hotfix : This hotfix is for logo backgriund getting misalinged due to frames. Position of data dot was calculated wrongly.