### PR TITLE
Hot fix for vertical logos getting expanded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobstac-awesome-qr",
-    "version": "2.4.7-beta.0",
+    "version": "2.4.8-beta.0",
     "description": "MobStac Awesome QR code library",
     "homepage": "https://github.com/mobstac/mobstac-awesome-qr",
     "bugs": "https://github.com/mobstac/mobstac-awesome-qr/issues",

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -1765,12 +1765,13 @@ export class SVGDrawing {
         if( rectangular ){
 
             let logoAreaMaxSide = maxLogoScale * this.config.size ;
-            let ratio = logoHeight / logoWidth ;
 
             if( logoHeight > logoWidth ){
+                let ratio = logoWidth / logoHeight ;
                 logoAreaHeight = logoAreaMaxSide;
                 logoAreaWidth = logoAreaHeight * ratio ;
             } else {
+                let ratio = logoHeight / logoWidth ;
                 logoAreaWidth = logoAreaMaxSide ;
                 logoAreaHeight = logoAreaWidth * ratio ;
             }


### PR DESCRIPTION
This PR is for fixing vertical logos getting expanded due to miscalculation of ratio while setting logo dimensions.