### PR TITLE
Fix viewbox height for QR Codes with Barcode and Barcode Value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobstac-awesome-qr",
-    "version": "2.5.4",
+    "version": "2.5.6",
     "description": "MobStac Awesome QR code library",
     "homepage": "https://github.com/mobstac/mobstac-awesome-qr",
     "bugs": "https://github.com/mobstac/mobstac-awesome-qr/issues",

--- a/src/Svg.ts
+++ b/src/Svg.ts
@@ -272,8 +272,16 @@ export class SVGDrawing {
                     // @ts-ignore
                     canvas.height(null);
                     if(frameStyle === QRCodeFrame.CIRCULAR){
+                        // Using canvasWidth since canvasWidth and canvasHeight are same 
+                        let viewBoxHeight = canvasWidth;
+                        if( this.config.showBarcode) {
+                            viewBoxHeight = viewBoxHeight + 400;
+                        }   
+                        if( this.config.showBarcodeValue ) {
+                            viewBoxHeight = viewBoxHeight + 200;
+                        }
                         //@ts-ignore
-                        canvas.viewbox(0, 0, canvasWidth + 190, canvasWidth + 190)
+                        canvas.viewbox(0, 0, canvasWidth + 190, viewBoxHeight + 190)
                     }
                 }
                 // @ts-ignore


### PR DESCRIPTION
Increase Viewbox height for Circular frames when showBarcode or showBarcodeValue are true