### PR TITLE
Fix circular frame overflow issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mobstac-awesome-qr",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "MobStac Awesome QR code library",
     "homepage": "https://github.com/mobstac/mobstac-awesome-qr",
     "bugs": "https://github.com/mobstac/mobstac-awesome-qr/issues",


### PR DESCRIPTION
### Summary
<!-- Provide the general summary, context/motivation of your changes in the title above -->
Fix circular frame overflow issue

### Description
<!--Describe your changes in details -->
- The SVG's viewBox attribute was using outdated canvas dimensions that didn't account for the stroke width of the circular border.
- Fixed the viewBox calculation to use actual canvas dimensions instead of hardcoded values.

### Related Links / Trello / Intercom / Github
<!-- If it fixes an open issue,link the issue here.-->
https://trello.com/c/GtlzqDeL

### Affected Service(s) / Component(s)
<!-- List all the affected services/components -->
Generator

### Type of change (use labels) - bug / refactor / feature …
<!-- type of change -->
Bug

### How have I tested this?
<!-- provide instructions on how you have tested this change, and test cases written.-->
Tested it on staging environment for both POLO and Uniqode

### Risks
<!-- put an `x` in of the following -->

- [x] **low** : backward compatible,new feature or patches which do not break existing functionality.

- [ ] **medium** : existing functionality in our domain got altered but this does not break contracts with other domains.

- [ ] **high** : breaking contracts with other domains.

### PR Dependency
Link of PR(s) that need to be merged before this PR.
None